### PR TITLE
update retriable dependency

### DIFF
--- a/google_maps_service.gemspec
+++ b/google_maps_service.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'multi_json', '~> 1.11'
   spec.add_runtime_dependency 'hurley', '~> 0.1'
-  spec.add_runtime_dependency 'retriable', '~> 2.0'
+  spec.add_runtime_dependency 'retriable', '~> 3.0'
 end


### PR DESCRIPTION
Update retriable dependency from 2.0 to 3.0. I checked the retriable changelog and there's only one breaking change, which is when you send a hash to on:. Because this gem sends an array to on:, no changes should be required.